### PR TITLE
Set the correct vscode engine compatibiltiy

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "publisher": "formulahendry",
     "icon": "images/logo.png",
     "engines": {
-        "vscode": "^1.5.0"
+        "vscode": "^1.26.0"
     },
     "categories": [
         "Extension Packs",


### PR DESCRIPTION
vscode engine should be set to `^1.26` because older VS Code versions does not support `extensionPack` property

@formulahendry Please have this change before publishing the extension